### PR TITLE
Replace deprecated keyCode with key

### DIFF
--- a/assets/js/store-common.js
+++ b/assets/js/store-common.js
@@ -36,7 +36,7 @@ function modal(url, markdown=false) {
     }
   }
   document.addEventListener('keyup', function(e) {
-    if (e.keyCode == 27) {
+    if (e.key === 'Esc' || e.key === 'Escape') {
       hide_element('modal');
       hide_element('dropdown');
     }

--- a/assets/js/store-common.js
+++ b/assets/js/store-common.js
@@ -36,7 +36,7 @@ function modal(url, markdown=false) {
     }
   }
   document.addEventListener('keyup', function(e) {
-    if (e.key === 'Esc' || e.key === 'Escape') {
+    if (e.key === 'Escape' || e.key === 'Esc') {
       hide_element('modal');
       hide_element('dropdown');
     }


### PR DESCRIPTION
`keyCode` is deprecated and a replacement should be used. In this PR, I decided to go with `key` instead.

Note that the code checks for both `Esc` and `Escape` as depending on the browser, `Esc` may be returned instead of `Escape`. Specifically, this happens for IE and earlier versions of Firefox.

According to https://caniuse.com/ support is great for `KeyboardEvent.key`.