### PR TITLE
Refactored modal function in store-common.js

### DIFF
--- a/assets/js/store-common.js
+++ b/assets/js/store-common.js
@@ -2,28 +2,24 @@ function modal(url, markdown=false) {
     var modal = document.getElementsByClassName('modal');
     fetch(url).then(function (response) {
       return response.text().then(function (text) {
-        if (markdown) {
-            modal[0].innerHTML = `<div>
-                <div class="reader">${marked.parse(text)}</div>
-                    <div class="actions">
-                    <a class="button icon-slot" onclick="hide_element('modal')">
-                      <ion-icon class="icon" name="close-outline"></ion-icon>
-                        Close
-                    </a>
-                </div>`;
-        } else {
-            var data =
-            modal[0].innerHTML = `<div>
-                <pre><code class="language-yaml">${text}</code></pre>
-                <div class="actions">
-                <a class="button icon-slot" onclick="hide_element('modal')">
-                  <ion-icon class="icon" name="close-outline"></ion-icon>
-                    Close
-                </a>
-                </div>`;
+        modal[0].innerHTML = getModalMarkup();
+
+        if (!markdown) {
             hljs.highlightAll();
         }
+        
         modal[0].classList.add('show');
+
+        function getModalMarkup() {
+          return `<div>` +
+          markdown ? `<div class="reader">${marked.parse(text)}</div>` : `<pre><code class="language-yaml">${text}</code></pre>` +
+          `<div class="actions">
+            <a class="button icon-slot" onclick="hide_element('modal')">
+              <ion-icon class="icon" name="close-outline"></ion-icon>
+                Close
+            </a>
+          </div>`;
+        }
       }).catch(function (err) {
         console.log(err);
       });

--- a/assets/js/store-common.js
+++ b/assets/js/store-common.js
@@ -12,7 +12,7 @@ function modal(url, markdown=false) {
 
         function getModalMarkup() {
           return `<div>` +
-          markdown ? `<div class="reader">${marked.parse(text)}</div>` : `<pre><code class="language-yaml">${text}</code></pre>` +
+          (markdown ? `<div class="reader">${marked.parse(text)}</div>` : `<pre><code class="language-yaml">${text}</code></pre>`) +
           `<div class="actions">
             <a class="button icon-slot" onclick="hide_element('modal')">
               <ion-icon class="icon" name="close-outline"></ion-icon>


### PR DESCRIPTION
Currently, there was duplication of markup in the `modal` function. This PR aims to simplify the code there and reuse the markup as much as possible by adding a `getModalMarkup` function.

Pulling in markup from a separate function also technically makes the code more readable, as there is no markup "polluting" the actual code in that case.

I did some initial testing and there were no bugs introduced with this PR, but I have very minimal understanding of the project so perhaps there are indeed issues.