### PR TITLE
Improved card functionality

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -867,7 +867,6 @@ ul.cards {
 ul.cards li {
     list-style: none;
     background-color: #fff;
-    padding: .8rem;
     margin: 0 0 .8rem 0;
     border-radius: .3em;
     border: 1px solid #d2d2d2;
@@ -880,16 +879,13 @@ ul.cards.inline li {
 }
 
 ul.cards li.link {
-    padding: 0;
-}
-
-ul.cards li.link {
-    display: block;
-    padding: 1em 2em;
+    display: flex;
 }
 
 ul.cards li a {
+    width: 100%;
     text-decoration: none;
+    padding: 1em 2em;
 }
 
 ul.cards.has-hover li:hover,


### PR DESCRIPTION
Currently, when hovering over a `li` that's inside a `cards` container, the behavior is inconsistent.

The general user expectation is that clicking anywhere within the card should redirect to the desired page, but that is not what happens currently. Some areas inside the box are unclickable: no pointer cursor, and the `a` element does not fill the entirety of the box's width and height.

This issue is further exacerbated by the fact that the card's border changes when the user hovers it.

This PR aims to fix that by moving the padding from the `li` element to the `a`, among other changes. This is probably not the best implementation and there are better ways of doing it, but hopefully this is a good start.
