### PR TITLE
Fixed icon alignment in h2 for feature-display

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1282,6 +1282,8 @@ input[type="search"]:focus {
 }
 
 .feature-display.center .description h2 {
+    display: flex;
+    align-items: center;
     justify-content: center;
 }
 


### PR DESCRIPTION
There is a small bug with `feature-display` elements that are centered and are section titles. For example, when looking at the main page, the **Safe. Sandboxed.** section has an issue with the title and icon alignment.

This PR fixes that, and potentially other cases of this kind, in the future.