### PR TITLE
Add jekyll-sitemap plugin to generate proper sitemap required for proper crawling for search engines

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,4 @@ navigation_right:
 
 plugins:
   - jekyll-feed
+  - jekyll-sitemap


### PR DESCRIPTION
Ref: https://github.com/jekyll/jekyll-sitemap

- Demo of the page locally generated using `jekyll`:-

![image](https://user-images.githubusercontent.com/26346867/215114901-10aac145-661e-4a98-b4dd-c74d60a98d3a.png)
