### PR TITLE
Add base URL to fix sitemap generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: Easily run Windows software on Linux with 🍷 Bottles!
 author: Bottles Developers
 email: mail@usebottles.com
 logo: /uploads/logo.svg?v4
+url: https://usebottles.com/
 
 assets: /assets
 uploads: /uploads


### PR DESCRIPTION
Adding the base URL to the config as it is required for [the plugin](https://github.com/jekyll/jekyll-sitemap).