### PR TITLE
Added Ruby Gemfile and Gemspec for CI Build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
+gem 'jekyll'
+gem "jekyll-sass-converter", "~> 2.0"
 gemspec

--- a/bottles-website-jekyll.gemspec
+++ b/bottles-website-jekyll.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.name                    = "bottles-website"
+  spec.version                 = "50.2"
+  spec.authors                 = ["Bottles Developers"]
+
+  spec.summary                 = %q{Official Bottles website.}
+  spec.homepage                = "https://github.com/bottlesdevs/website"
+  spec.license                 = "GNU Affero General Public License v3.0"
+
+  spec.metadata["plugin_type"] = "theme"
+
+  spec.files                   = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r{^(assets|_(data|includes|layouts|sass)/|(LICENSE|README|CHANGELOG)((\.(txt|md|markdown)|$)))}i)
+  end
+
+  spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"
+  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.3"
+  spec.add_runtime_dependency "jekyll-gist", "~> 1.5"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.1"
+  spec.add_runtime_dependency "jekyll-include-cache", "~> 0.1"
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake", ">= 12.3.3"
+end


### PR DESCRIPTION
With this pull request I introduced two files (Ruby Gemfile and Gemspec) that allow the site to be compiled correctly via Jekyll without installing system dependencies but only through bundler / gem

Build tested with:
- Local Jekyll
- Cloudflare CI
- Github CI