### PR TITLE
Remove "new" tag from the "Install programs in one click" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ description: Run Windows programs on Linux.
 <section class="hero invert purple">
   <div class="feature-display invert">
     <div class="description">
-      <h2>Install programs <u>in one click</u><span class="badge new">New</span></h2>
+      <h2>Install programs <u>in one click</u></h2>
       <p>Installers (introduced in 2022.2.14) are an easy way to install games 
         and applications into your bottles.</p>
       <p>Installers are instruction sets written by our community, which 


### PR DESCRIPTION
This PR removes the "new" tag from the "Install programs in one click" section, as the the feature is now 2 years old now.