### PR TITLE
cleanup: switch npm to pnpm in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ All commands are run from the root of the project, from a terminal:
 
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+| `pnpm install`             | Installs dependencies                            |
+| `pnpm run dev`             | Starts local dev server at `localhost:4321`      |
+| `pnpm run build`           | Build your production site to `./dist/`          |
+| `pnpm run preview`         | Preview your build locally, before deploying     |
+| `pnpm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `pnpm run astro -- --help` | Get help using the Astro CLI                     |
+
+It's recommended to use `pnpm` as the package manager.
 
 ## License
 


### PR DESCRIPTION
Since `pnpm` is used for the project, I belive it's better that the command also reflect that, and it will avoid having both `pnpm-lock.yml` and `package-lock.json` in the files roots when new contributors are doing a pull request