### PR TITLE
cleanup: add content width to the links in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,11 +16,10 @@ import { Icon } from 'astro-icon/components'
     <div>
       <h3 class="font-bold text-lg mb-3 text-gray-900 dark:text-white">Community</h3>
       <ul class="space-y-2">
-        <li><a href="https://forum.usebottles.com/" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="material-symbols:chat" class="w-5 h-5 mr-2"/>Forums</a></li>
-        <li><a href="https://twitter.com/usebottles" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:twitter" class="w-5 h-5 mr-2"/>Twitter</a></li>
-        <li><a href="https://discord.gg/wF4JAdYrTR" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:discord" class="w-5 h-5 mr-2"/>Discord</a></li>
-        <li><a href="https://github.com/bottlesdevs" class="flex items-center text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:github" class="w-5 h-5 mr-2"/>GitHub</a></li>
-      </ul>
+      <li><a href="https://forum.usebottles.com/" class="flex items-center w-max text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="material-symbols:chat" class="w-5 h-5 mr-2"/>Forums</a></li>
+      <li><a href="https://twitter.com/usebottles" class="flex items-center w-max text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:twitter" class="w-5 h-5 mr-2"/>Twitter</a></li>
+      <li><a href="https://discord.gg/wF4JAdYrTR" class="flex items-center w-max text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:discord" class="w-5 h-5 mr-2"/>Discord</a></li>
+      <li><a href="https://github.com/bottlesdevs" class="flex items-center w-max text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"><Icon name="bxl:github" class="w-5 h-5 mr-2"/>GitHub</a></li>      </ul>
     </div>
 
     <!-- Support -->
@@ -52,4 +51,3 @@ import { Icon } from 'astro-icon/components'
     <a href="#" class="text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-400">distributed by fabricators.ltd</a>
   </div>
 </footer>
-


### PR DESCRIPTION
So you can't click where the text isn't there