### PR TITLE
cleanup: invert and grayscale the sponsor logos on dark mode

### DIFF
--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -3,22 +3,22 @@
 
   <div class="flex justify-center items-center gap-4 mb-4 flex-col md:flex-row">
     <a href="https://www.jetbrains.com/?from=bottles" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/jetbrains.png" alt="JetBrains" class="h-12" />
+      <img src="/assets/sponsors/jetbrains.png" alt="JetBrains" class="h-12 dark:grayscale dark:invert" />
     </a>
     <a href="https://www.gitbook.com/?ref=bottles" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/gitbook.png" alt="GitBook" class="h-12" />
+      <img src="/assets/sponsors/gitbook.png" alt="GitBook" class="h-12 dark:grayscale dark:invert" />
     </a>
     <a href="https://www.linode.com/?from=bottles" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/linode-brand.png" alt="Linode" class="h-12" />
+      <img src="/assets/sponsors/linode-brand.png" alt="Linode" class="h-12 dark:grayscale dark:invert" />
     </a>
     <a href="https://appwrite.io?from=bottles" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/built-with-appwrite.svg" alt="Appwrite" class="h-12" />
+      <img src="/assets/sponsors/built-with-appwrite.svg" alt="Appwrite" class="h-12 dark:grayscale dark:invert" />
     </a>
     <a href="https://hyperbit.it/" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/HyperBit_Dark_Logo.png" alt="Hyperbitz" class="h-12" />
+      <img src="/assets/sponsors/HyperBit_Dark_Logo.png" alt="Hyperbitz" class="h-12 dark:grayscale dark:invert" />
     </a>
     <a href="https://www.scaleway.com/en/" target="_blank" rel="noopener noreferrer">
-      <img src="/assets/sponsors/Scaleway_FOSS.png" alt="Scaleway" class="h-12" />
+      <img src="/assets/sponsors/Scaleway_FOSS.png" alt="Scaleway" class="h-12 dark:grayscale dark:invert" />
     </a>
   </div>
 


### PR DESCRIPTION
A little suggestion from me 😄 

This way, we can be 90% sure that everything in the logo is seen on dark mode.

Before:

<img width="948" alt="image" src="https://github.com/user-attachments/assets/dcd930d0-6e4c-42ad-bd8c-2fc9f9045d5b">


After:

<img width="948" alt="image" src="https://github.com/user-attachments/assets/cac7081b-190d-4f3a-8b1d-1f1e68980395">

