### PR TITLE
fix(funding): contrast of liberapay and github on dark mode

### DIFF
--- a/src/pages/funding.astro
+++ b/src/pages/funding.astro
@@ -30,7 +30,7 @@ import { Icon } from "astro-icon/components";
 
       <div class="grid md:grid-cols-3 gap-6 mb-8">
         <div
-          class="bg-gray-900 text-white p-8 rounded-lg shadow-md text-center hover:shadow-lg transition-all relative top-0 hover:-top-1"
+          class="bg-gray-900 dark:bg-gray-800 text-white p-8 rounded-lg shadow-md text-center hover:shadow-lg transition-all relative top-0 hover:-top-1"
         >
           <Icon
             name="material-symbols:favorite-outline"
@@ -43,7 +43,7 @@ import { Icon } from "astro-icon/components";
           >
           <a
             href="https://github.com/sponsors/bottlesdevs"
-            class="mt-4 block bg-gray-800 text-white py-2 px-4 rounded-lg hover:bg-gray-700 transition-all"
+            class="mt-4 block bg-gray-800 dark:bg-gray-700 text-white py-2 px-4 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-600 transition-all"
             >Sponsor via GitHub</a
           >
         </div>
@@ -81,12 +81,12 @@ import { Icon } from "astro-icon/components";
           />
           <h3 class="text-2xl font-bold mb-2">LiberaPay</h3>
           <span
-            class="bg-yellow-500 dark:bg-yellow-600 text-gray-900 px-2 py-1 rounded-full text-sm inline-block mb-4"
+            class="bg-yellow-500 dark:bg-yellow-100 dark:bg-opacity-50 text-gray-900 px-2 py-1 rounded-full text-sm inline-block mb-4"
             >Flexible Subscription</span
           >
           <a
             href="https://liberapay.com/bottles"
-            class="mt-4 block bg-yellow-500 dark:bg-yellow-600 text-gray-900 py-2 px-4 rounded-lg hover:bg-yellow-300 transition-all"
+            class="mt-4 block bg-yellow-500 dark:bg-yellow-100 text-gray-900 py-2 px-4 rounded-lg hover:bg-yellow-300 dark:hover:bg-yellow-200 transition-all"
             >Donate via LiberaPay</a
           >
         </div>


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/fd4ecc7f-9fff-4431-9d21-9a6392a87aa8)

After:

![image](https://github.com/user-attachments/assets/f1bc4494-25da-45e7-adbc-d74e37f6a8ea)
