### PR TITLE
fix(appstore): bad contrast on hover

### DIFF
--- a/src/pages/appstore.astro
+++ b/src/pages/appstore.astro
@@ -171,10 +171,9 @@ class AppStore {
             <span class="px-2 py-1 rounded-lg text-sm ${this.getCategoryColor(installer.Category)}">${installer.Category}</span>
           </div>
         </div>
-        <div class="bg-gray-100 rounded-b-lg text-center flex gap-2 justify-between dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
-          <a class="block font-medium text-lg size-full p-2 hover:bg-gray-500 rounded-bl-lg" href="/app#${item}">Details</a>
-          <a class="block font-medium text-lg size-full p-2 hover:bg-gray-500 rounded-br-lg" href="https://docs.usebottles.com/bottles/installers#use-installers">Install</a>
-        </div>
+        <div class="bg-gray-100 rounded-b-lg text-center flex gap-2 justify-between dark:bg-gray-700 dark:text-gray-300">
+          <a class="block font-medium text-lg size-full p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-bl-lg" href="/app#${item}">Details</a>
+          <a class="block font-medium text-lg size-full p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-br-lg" href="https://docs.usebottles.com/bottles/installers#use-installers">Install</a>
       </div>
       `;
     }


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/5438cdc7-d472-4f9f-8583-9d363ce9c32a)

After:

![image](https://github.com/user-attachments/assets/35898775-26d9-4381-911a-a9685306eebe)

\* - Both photos above are the hover state of the "Install" button