### PR TITLE
Fix broken blog links

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+import { Routes, Route, useNavigate, useLocation, Navigate, useParams } from 'react-router-dom';
 import { LanguageProvider } from './i18n/LanguageContext';
 import Header from './components/Header';
 import Hero from './components/HeroReleased';
@@ -66,6 +66,11 @@ const App = () => {
         else navigate(`/${view}`);
     };
 
+    const RedirectToBlog = () => {
+        const { slug } = useParams();
+        return <Navigate to={`/blog/${slug}.md`} replace />;
+    };
+
     const isGaming = currentView === 'gaming';
 
     return (
@@ -99,6 +104,7 @@ const App = () => {
                             <Route path="/funding" element={<Funding />} />
                             <Route path="/blog" element={<Blog />} />
                             <Route path="/blog/:slug" element={<Blog />} />
+                            <Route path="/posts/:slug" element={<RedirectToBlog />} />
                             <Route path="/database" element={<DatabaseHome />} />
                             <Route path="/runners" element={<Runners />} />
                             <Route path="/next" element={<Next />} />

--- a/components/Funding.jsx
+++ b/components/Funding.jsx
@@ -12,7 +12,7 @@ const tasksData = [
     title: "Library mode",
     description: "Allow users to add any program from any bottle in a library view for easy access.",
     progress: 100,
-    link: "https://usebottles.com/posts/2022-08-28-release-2022.8.28",
+    link: "https://usebottles.com/blog/2022-08-28-release-2022.8.28.md",
   },
   {
     status: "ALPHA",
@@ -36,7 +36,7 @@ const tasksData = [
     title: "Integration of UMU",
     description: "Integration of UMU to enhance the gaming compatibility in Bottles.",
     progress: 10,
-    link: "https://usebottles.com/posts/2024-09-24-umu-next/",
+    link: "https://usebottles.com/blog/2024-09-24-umu-next.md",
     infoText: "Estimated time: 4 weeks of work based on average hourly cost.",
     icons: [{ name: 'build', title: 'In progress' }, { name: 'help', title: 'Needs funding' }]
   },
@@ -45,7 +45,7 @@ const tasksData = [
     title: "Bottles Next",
     description: "A complete redesign of Bottles to overcome current limitations and provide a consistent user experience across Linux and macOS.",
     progress: 15,
-    link: "https://usebottles.com/posts/2023-10-05-bottles-next-a-new-chapter/",
+    link: "https://usebottles.com/blog/2023-10-05-bottles-next-a-new-chapter.md",
     infoText: "We are looking for funds, contributors, and companies to provide infrastructure support.",
     icons: [{ name: 'build', title: 'In progress' }, { name: 'help', title: 'Needs funding' }]
   },

--- a/components/Next.jsx
+++ b/components/Next.jsx
@@ -307,7 +307,7 @@ const Next = () => {
                                     {t.nextPage.donations.supportButton}
                                 </a>
                                 <a
-                                    href="/posts/2025-08-04-nlnet-commons-fund"
+                                    href="/blog/2025-08-04-nlnet-commons-fund.md"
                                     className="w-full sm:w-auto px-8 py-4 rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-white font-bold hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
                                 >
                                     {t.nextPage.donations.readButton}
@@ -426,7 +426,7 @@ const Next = () => {
                 <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
                     <h2 className="text-3xl font-bold text-zinc-900 dark:text-white mb-12">{t.nextPage.readMore.title}</h2>
                     <div className="grid md:grid-cols-2 gap-8">
-                        <a href="/posts/2024-12-22-matter-of-technology" className="block group text-left">
+                        <a href="/blog/2024-12-22-matter-of-technology.md" className="block group text-left">
                             <div className="bg-white dark:bg-zinc-900 p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 hover:border-purple-500 dark:hover:border-purple-500 transition-colors h-full">
                                 <span className="text-sm text-zinc-500 mb-2 block">Dec 22, 2024</span>
                                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-2 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">
@@ -437,7 +437,7 @@ const Next = () => {
                                 </p>
                             </div>
                         </a>
-                        <a href="/posts/2024-12-27-rust-libcosmic-next" className="block group text-left">
+                        <a href="/blog/2024-12-27-rust-libcosmic-next.md" className="block group text-left">
                             <div className="bg-white dark:bg-zinc-900 p-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 hover:border-purple-500 dark:hover:border-purple-500 transition-colors h-full">
                                 <span className="text-sm text-zinc-500 mb-2 block">Dec 27, 2024</span>
                                 <h3 className="text-xl font-bold text-zinc-900 dark:text-white mb-2 group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">

--- a/posts/2024-09-24-umu-next.md
+++ b/posts/2024-09-24-umu-next.md
@@ -9,7 +9,7 @@ user_name: Mirko Brombin
 user_tag: Founder
 ---
 
-We’ve received many questions about [UMU](https://github.com/Open-Wine-Components/umu-launcher) in Bottles and the current development of [Bottles Next](https://usebottles.com/posts/2023-10-05-bottles-next-a-new-chapter/). In this brief article, we’ll try to answer these questions.
+We’ve received many questions about [UMU](https://github.com/Open-Wine-Components/umu-launcher) in Bottles and the current development of [Bottles Next](https://usebottles.com/blog/2023-10-05-bottles-next-a-new-chapter.md). In this brief article, we’ll try to answer these questions.
 
 ## UMU in Bottles
 

--- a/posts/2024-12-02-future-of-bottles.md
+++ b/posts/2024-12-02-future-of-bottles.md
@@ -49,7 +49,7 @@ Bottles has a bright future, with ongoing projects like:
 - [DONE] **Library Mode**: Seamless access to programs in a library view
 - [ALPHA] **Per-Bottle Sandbox**: Enhanced security through isolated environments
 - [WIP] **Layered Bottles**: Supporting multiple environments in one bottle
-- [NEXT] **Bottles Next** [[i]](https://usebottles.com/posts/2023-10-05-bottles-next-a-new-chapter/): A complete overhaul with modular architecture for Linux and macOS compatibility
+- [NEXT] **Bottles Next** [[i]](https://usebottles.com/blog/2023-10-05-bottles-next-a-new-chapter.md): A complete overhaul with modular architecture for Linux and macOS compatibility
 
 Each feature brings us closer to realizing Bottles’ full potential, but we need your help to get there. Visit our [Funding Page](https://usebottles.com/funding/) to learn more and contribute.
 

--- a/posts/2024-12-22-matter-of-technology.md
+++ b/posts/2024-12-22-matter-of-technology.md
@@ -9,7 +9,7 @@ user_name: Mirko Brombin
 user_tag: Founder
 ---
 
-More than a year ago, we [announced](https://usebottles.com/posts/2023-10-05-bottles-next-a-new-chapter/) the beginning of the development of Bottles Next, a project aimed at solving a large number of architectural problems in Bottles' source code—issues that to date have prevented the implementation of new features without significant complications.
+More than a year ago, we [announced](https://usebottles.com/blog/2023-10-05-bottles-next-a-new-chapter.md) the beginning of the development of Bottles Next, a project aimed at solving a large number of architectural problems in Bottles' source code—issues that to date have prevented the implementation of new features without significant complications.
 
 ![Bottles Next](https://usebottles.com/uploads/bottles-next-classic-bottle-details.png)
 

--- a/posts/2024-12-27-rust-libcosmic-next.md
+++ b/posts/2024-12-27-rust-libcosmic-next.md
@@ -9,7 +9,7 @@ user_name: Mirko Brombin
 user_tag: Founder
 ---
 
-Over a year ago, we [announced Bottles Next](https://usebottles.com/posts/2023-10-05-bottles-next-a-new-chapter/), a complete rewrite of the Bottles project. Initially, the idea was to leverage web technologies to achieve the experience we envisioned for our users. However, as is often the case, extensive research, discussions, experiments, and continuous re-evaluations followed.
+Over a year ago, we [announced Bottles Next](https://usebottles.com/blog/2023-10-05-bottles-next-a-new-chapter.md), a complete rewrite of the Bottles project. Initially, the idea was to leverage web technologies to achieve the experience we envisioned for our users. However, as is often the case, extensive research, discussions, experiments, and continuous re-evaluations followed.
 
 Why go through all this trouble? Well, to ensure we make the right choices.
 
@@ -61,7 +61,7 @@ We’ll also announce the public repositories where you can follow the ongoing w
 
 We kindly ask you to **consider making a donation**, even a small one, to help support development timelines and cover any necessary resources. For those interested, [visit our dedicated page](https://usebottles.com/funding/).
 
-We deeply appreciate your support for the [future of Bottles](https://usebottles.com/posts/2024-12-02-future-of-bottles/).
+We deeply appreciate your support for the [future of Bottles](https://usebottles.com/blog/2024-12-02-future-of-bottles.md).
 
 ## GTK?
 

--- a/posts/2025-08-04-nlnet-commons-fund.md
+++ b/posts/2025-08-04-nlnet-commons-fund.md
@@ -7,7 +7,7 @@ pubDate: 2025-08-04
 
 We are really happy to announce that [Bottles](https://nlnet.nl/project/Bottles/) has been awarded a grant from the **NLnet Foundation** through the **2025 Commons Fund**.
 
-This support will help us accelerate our work on the [Bottles Next](/posts/2023-10-05-bottles-next-a-new-chapter) project (also read [here](/posts/2024-12-27-rust-libcosmic-next) for updates), bringing a more modern and polished experience to running Windows software on Linux. The grant recognizes our efforts to build a better future for running Windows applications on Linux.
+This support will help us accelerate our work on the [Bottles Next](/blog/2023-10-05-bottles-next-a-new-chapter.md) project (also read [here](/blog/2024-12-27-rust-libcosmic-next.md) for updates), bringing a more modern and polished experience to running Windows software on Linux. The grant recognizes our efforts to build a better future for running Windows applications on Linux.
 
 We are incredibly thankful to the NLnet Foundation and the Commons Fund for believing in our mission.
 

--- a/posts/2025-08-16-bottles-and-nlnet.md
+++ b/posts/2025-08-16-bottles-and-nlnet.md
@@ -7,7 +7,7 @@ pubDate: 2025-08-16
 
 Hello everyone,
 
-A few days ago, the news broke that Bottles had received the [green light from NLnet](https://usebottles.com/posts/2025-08-04-nlnet-commons-fund/). This was wonderful news, which made us proud and energized. However, reading the media headlines and some comments from the community, I realized that perhaps some clarity is needed.
+A few days ago, the news broke that Bottles had received the [green light from NLnet](https://usebottles.com/blog/2025-08-04-nlnet-commons-fund.md). This was wonderful news, which made us proud and energized. However, reading the media headlines and some comments from the community, I realized that perhaps some clarity is needed.
 
 **First important thing: we haven't received the funding.**
 A European call for proposals doesn't work like a direct bank transfer to a project's account. It works like this: the project is selected, receives the "green light," and from that moment on, a process of discussion and planning begins to define the actual budget it will be eligible for and how it will be spent. In our case, these funds will be dedicated to Bottles Next, not Bottles in its current form.


### PR DESCRIPTION
Fixes #89 

- edited all the "/posts/{slug}" links to "/blog/{slug}.md" 
- added a redirect for backwards compatibility